### PR TITLE
feat: add form stability bit, improved optional validation

### DIFF
--- a/apps/demo/src/forms/shipmentOptionsForm.tsx
+++ b/apps/demo/src/forms/shipmentOptionsForm.tsx
@@ -262,9 +262,17 @@ export const shipmentOptionsForm = defineForm('shipmentOptions', {
     }),
 
     defineField({
+      name: 'bsn',
+      component: TTextInput,
+      ref: ref(''),
+      label: 'bsn',
+      optionalWhen: (field) => field.form.getValue('ageCheck') === false,
+    }),
+
+    defineField({
       name: 'signature',
       component: TToggleSwitch,
-      ref: ref(true),
+      ref: ref(false),
       label: 'shipment_option_signature',
       visibleWhen: (field) => field.form.getValue('packageType') === PackageTypeName.Package,
     }),
@@ -322,11 +330,18 @@ export const shipmentOptionsForm = defineForm('shipmentOptions', {
       validate: (field, value) => value > 100,
       errorMessage: 'Insurance must be at least 100',
       visibleWhen: (field) => field.form.getValue('packageType') === PackageTypeName.Package,
-      optionalWhen: () => true,
       props: {
         step: 100,
         min: 100,
       },
+    }),
+
+    defineField({
+      name: 'deliveryMessage',
+      component: TTextInput,
+      ref: ref(''),
+      label: 'delivery_message',
+      optionalWhen: (field) => !field.form.getValue('signature'),
     }),
 
     defineField({

--- a/apps/demo/src/translate.ts
+++ b/apps/demo/src/translate.ts
@@ -24,6 +24,8 @@ const translations: Record<string, string> = Object.freeze({
   shipment_option_signature: 'Handtekening',
   shipment_options_title: 'Verzendopties',
   street: 'Straat',
+  delivery_message: 'Bericht aan de bezorger',
+  bsn: 'BSN',
 });
 
 export function translate(key: string): string {

--- a/libs/core/src/form/Form.ts
+++ b/libs/core/src/form/Form.ts
@@ -14,6 +14,7 @@ export const FORM_HOOKS = ['beforeSubmit', 'afterSubmit', 'beforeValidate', 'aft
 export class Form<FC extends InstanceFormConfiguration = InstanceFormConfiguration, FN extends string = string> {
   public readonly name: FN;
 
+  public readonly stable: FormInstance<FC>['stable'] = ref(false);
   public readonly config: Omit<FC, 'fields'>;
   public readonly hooks: FormInstance<FC>['hooks'];
   public readonly model = {} as FormInstance<FC>['model'];
@@ -56,6 +57,7 @@ export class Form<FC extends InstanceFormConfiguration = InstanceFormConfigurati
         return isOfType<InteractiveElementInstance>(field, 'ref');
       });
     });
+    this.stable.value = true;
   }
 
   public addElement(element: AnyElementConfiguration, sibling?: string, position: 'before' | 'after' = 'after'): void {

--- a/libs/core/src/form/Form.types.ts
+++ b/libs/core/src/form/Form.types.ts
@@ -91,6 +91,11 @@ export type BaseFormInstance<FC extends FormConfiguration = FormConfiguration> =
   readonly name: string;
 
   /**
+   * Whether the form is stable. A form is stable when it is done first initialization and all fields are available.
+   */
+  readonly stable: Ref<boolean>;
+
+  /**
    * Form configuration.
    */
   readonly config: Omit<FC, 'fields'>;


### PR DESCRIPTION
Required to ensure we can properly use optionalWhen predicates on fields.
The stability bit ensures we can target and query any field in any ordering in the optionalWhen predicates.