### PR TITLE
fix: fix setting ref values and pass down slots and attrs

### DIFF
--- a/libs/core/src/__tests__/form/field.spec.ts
+++ b/libs/core/src/__tests__/form/field.spec.ts
@@ -164,4 +164,36 @@ describe('Form fields', () => {
 
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it('it can invalidate a field', async () => {
+    expect.assertions(1);
+
+    const field = defineField({
+      component: 'input',
+      name: 'element',
+      ref: ref(''),
+    });
+
+    const {instance: form} = await generateTestForm<{element: string}>([field]);
+    const fieldInstance = form.getField('element');
+    fieldInstance.setInvalid();
+
+    expect(fieldInstance?.isValid.value).toBe(false);
+  });
+
+  it('can add an error to a field', async () => {
+    expect.assertions(1);
+
+    const field = defineField({
+      component: 'input',
+      name: 'element',
+      ref: ref(''),
+    });
+
+    const {instance: form} = await generateTestForm<{element: string}>([field]);
+    const fieldInstance = form.getField('element');
+    fieldInstance.addError('error message');
+
+    expect(fieldInstance?.errors.value).toEqual(['error message']);
+  });
 });

--- a/libs/core/src/form/Field.ts
+++ b/libs/core/src/form/Field.ts
@@ -5,7 +5,7 @@ import {type CustomHookItem, createHookManager} from '@myparcel-vfb/hook-manager
 import {isOfType, asyncEvery, type PromiseOr} from '@myparcel/ts-utils';
 import {isRequired} from '../validators';
 import {normalizeFieldConfiguration} from '../utils/normalizeFieldConfiguration';
-import {useDynamicWatcher} from '../utils';
+import {useDynamicWatcher, updateMaybeRef} from '../utils';
 import {
   type ToRecord,
   type FieldConfiguration,
@@ -160,57 +160,27 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
   };
 
   public setValue(value: Type): void {
-    if (isRef(this.ref)) {
-      this.ref.value = value;
-    } else {
-      // @ts-expect-error todo
-      this.ref = value;
-    }
+    updateMaybeRef(this.ref, value);
   }
 
   public setDisabled(value: boolean): void {
-    if (isRef(this.isDisabled)) {
-      this.isDisabled.value = value;
-    } else {
-      // @ts-expect-error update types to for when the refs are unwrapped
-      this.isDisabled = value;
-    }
+    updateMaybeRef(this.isDisabled, value);
   }
 
   public setOptional(value: boolean): void {
-    if (isRef(this.isOptional)) {
-      this.isOptional.value = value;
-    } else {
-      // @ts-expect-error update types to for when the refs are unwrapped
-      this.isOptional = value;
-    }
+    updateMaybeRef(this.isOptional, value);
   }
 
   public setReadOnly(value: boolean): void {
-    if (isRef(this.isReadOnly)) {
-      this.isReadOnly.value = value;
-    } else {
-      // @ts-expect-error update types to for when the refs are unwrapped
-      this.isReadOnly = value;
-    }
+    updateMaybeRef(this.isReadOnly, value);
   }
 
   public addError(error: string): void {
-    if (isRef(this.errors)) {
-      this.errors.value.push(error);
-    } else {
-      // @ts-expect-error update types to for when the refs are unwrapped
-      this.errors.push(error);
-    }
+    updateMaybeRef(this.errors, [...toValue(this.errors), error]);
   }
 
   public setInvalid(): void {
-    if (isRef(this.isValid)) {
-      this.isValid.value = false;
-    } else {
-      // @ts-expect-error update types to for when the refs are unwrapped
-      this.isValid = false;
-    }
+    updateMaybeRef(this.isValid, false);
   }
 
   public validate = async (): Promise<boolean> => {

--- a/libs/core/src/form/Field.ts
+++ b/libs/core/src/form/Field.ts
@@ -130,35 +130,6 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     this.destroyHandles.value.push(stopRefWatcher);
   }
 
-  private initializeWatchers(
-    config: FieldConfiguration<Type, Props>,
-    resolvedConfig: FieldConfiguration<Type, Props>,
-  ): void {
-    (
-      [
-        [config.visibleWhen, this.isVisible, resolvedConfig.visible],
-        [config.disabledWhen, this.isDisabled, resolvedConfig.disabled],
-        [config.optionalWhen, this.isOptional, resolvedConfig.optional],
-        [config.readOnlyWhen, this.isReadOnly, resolvedConfig.readOnly],
-      ] satisfies [
-        undefined | ((instance: FieldInstance<Type, Props>) => PromiseOr<boolean>),
-        Ref<boolean>,
-        boolean | undefined,
-      ][]
-    ).forEach(([configProperty, computedProperty, staticProperty]) => {
-      if (!isDefined(configProperty)) {
-        return;
-      }
-
-      computedProperty.value = staticProperty;
-
-      // @ts-expect-erro todo
-      const stopHandler = useDynamicWatcher(() => configProperty(this), computedProperty);
-
-      this.destroyHandles.value.push(stopHandler);
-    });
-  }
-
   public blur = async (): Promise<void> => {
     await this.hooks.execute('beforeBlur', this, toValue(this.ref));
 
@@ -192,6 +163,7 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     if (isRef(this.ref)) {
       this.ref.value = value;
     } else {
+      // @ts-expect-error todo
       this.ref = value;
     }
   }
@@ -200,6 +172,7 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     if (isRef(this.isDisabled)) {
       this.isDisabled.value = value;
     } else {
+      // @ts-expect-error update types to for when the refs are unwrapped
       this.isDisabled = value;
     }
   }
@@ -208,6 +181,7 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     if (isRef(this.isOptional)) {
       this.isOptional.value = value;
     } else {
+      // @ts-expect-error update types to for when the refs are unwrapped
       this.isOptional = value;
     }
   }
@@ -216,6 +190,7 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     if (isRef(this.isReadOnly)) {
       this.isReadOnly.value = value;
     } else {
+      // @ts-expect-error update types to for when the refs are unwrapped
       this.isReadOnly = value;
     }
   }
@@ -224,6 +199,7 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     if (isRef(this.errors)) {
       this.errors.value.push(error);
     } else {
+      // @ts-expect-error update types to for when the refs are unwrapped
       this.errors.push(error);
     }
   }
@@ -232,6 +208,7 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     if (isRef(this.isValid)) {
       this.isValid.value = false;
     } else {
+      // @ts-expect-error update types to for when the refs are unwrapped
       this.isValid = false;
     }
   }
@@ -282,6 +259,35 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
 
     return toValue(this.isValid);
   };
+
+  private initializeWatchers(
+    config: FieldConfiguration<Type, Props>,
+    resolvedConfig: FieldConfiguration<Type, Props>,
+  ): void {
+    (
+      [
+        [config.visibleWhen, this.isVisible, resolvedConfig.visible],
+        [config.disabledWhen, this.isDisabled, resolvedConfig.disabled],
+        [config.optionalWhen, this.isOptional, resolvedConfig.optional],
+        [config.readOnlyWhen, this.isReadOnly, resolvedConfig.readOnly],
+      ] satisfies [
+        undefined | ((instance: FieldInstance<Type, Props>) => PromiseOr<boolean>),
+        Ref<boolean>,
+        boolean | undefined,
+      ][]
+    ).forEach(([configProperty, computedProperty, staticProperty]) => {
+      if (!isDefined(configProperty)) {
+        return;
+      }
+
+      computedProperty.value = staticProperty;
+
+      // @ts-expect-erro todo
+      const stopHandler = useDynamicWatcher(() => configProperty(this), computedProperty);
+
+      this.destroyHandles.value.push(stopHandler);
+    });
+  }
 
   private createValidators(config: FieldConfiguration<Type, Props>): void {
     let validators: Validator<Type, Props>[] = [];

--- a/libs/core/src/form/Field.ts
+++ b/libs/core/src/form/Field.ts
@@ -280,9 +280,9 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
         return;
       }
 
+      // @ts-expect-error todo
       computedProperty.value = staticProperty;
 
-      // @ts-expect-erro todo
       const stopHandler = useDynamicWatcher(() => configProperty(this), computedProperty);
 
       this.destroyHandles.value.push(stopHandler);

--- a/libs/core/src/form/Field.ts
+++ b/libs/core/src/form/Field.ts
@@ -228,6 +228,14 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
     }
   }
 
+  public setInvalid(): void {
+    if (isRef(this.isValid)) {
+      this.isValid.value = false;
+    } else {
+      this.isValid = false;
+    }
+  }
+
   public validate = async (): Promise<boolean> => {
     this.resetValidation();
     await this.hooks.execute('beforeValidate', this, toValue(this.ref));

--- a/libs/core/src/form/Field.ts
+++ b/libs/core/src/form/Field.ts
@@ -1,5 +1,5 @@
 // noinspection JSUnusedGlobalSymbols
-import {ref, watch, toValue, reactive, type UnwrapNestedRefs, computed, markRaw, type Ref} from 'vue';
+import {ref, watch, toValue, reactive, type UnwrapNestedRefs, computed, markRaw, type Ref, isRef} from 'vue';
 import {isDefined} from '@vueuse/core';
 import {type CustomHookItem, createHookManager} from '@myparcel-vfb/hook-manager';
 import {isOfType, asyncEvery, type PromiseOr} from '@myparcel/ts-utils';
@@ -189,19 +189,43 @@ export class Field<Type = unknown, Props extends ComponentProps = ComponentProps
   };
 
   public setValue(value: Type): void {
-    this.ref.value = value;
+    if (isRef(this.ref)) {
+      this.ref.value = value;
+    } else {
+      this.ref = value;
+    }
   }
 
   public setDisabled(value: boolean): void {
-    this.isDisabled.value = value;
+    if (isRef(this.isDisabled)) {
+      this.isDisabled.value = value;
+    } else {
+      this.isDisabled = value;
+    }
   }
 
   public setOptional(value: boolean): void {
-    this.isOptional.value = value;
+    if (isRef(this.isOptional)) {
+      this.isOptional.value = value;
+    } else {
+      this.isOptional = value;
+    }
   }
 
   public setReadOnly(value: boolean): void {
-    this.isReadOnly.value = value;
+    if (isRef(this.isReadOnly)) {
+      this.isReadOnly.value = value;
+    } else {
+      this.isReadOnly = value;
+    }
+  }
+
+  public addError(error: string): void {
+    if (isRef(this.errors)) {
+      this.errors.value.push(error);
+    } else {
+      this.errors.push(error);
+    }
   }
 
   public validate = async (): Promise<boolean> => {

--- a/libs/core/src/types/field.types.ts
+++ b/libs/core/src/types/field.types.ts
@@ -249,6 +249,8 @@ export interface FieldInstance<Type = unknown, Props extends ComponentProps = Co
 
   setReadOnly(optional: boolean): void;
 
+  addError(error: string): void;
+
   setVisible(value: boolean): void;
 }
 

--- a/libs/core/src/types/field.types.ts
+++ b/libs/core/src/types/field.types.ts
@@ -252,6 +252,8 @@ export interface FieldInstance<Type = unknown, Props extends ComponentProps = Co
   addError(error: string): void;
 
   setVisible(value: boolean): void;
+
+  setInvalid(): void;
 }
 
 export type ElementProp<Type = unknown, Props = ComponentProps> = UnwrapNestedRefs<FieldInstance<Type, Props>>;

--- a/libs/core/src/utils/createField.spec.ts
+++ b/libs/core/src/utils/createField.spec.ts
@@ -26,7 +26,7 @@ describe('createField', () => {
     const field = createField({name: 'test', ref: ref('value'), component: 'input'});
 
     expect(field).toStrictEqual({
-      Component: expect.objectContaining({render: expect.any(Function)}),
+      Component: expect.any(Function),
       Errors: expect.objectContaining({__asyncLoader: expect.any(Function)}),
       Label: expect.objectContaining({__asyncLoader: expect.any(Function)}),
       field: {name: 'test', ref: 'value', component: 'input'},
@@ -38,7 +38,7 @@ describe('createField', () => {
     const field = createField({name: 'test', ref: ref('value2'), component: testComponent});
 
     expect(field).toStrictEqual({
-      Component: expect.objectContaining({render: expect.any(Function)}),
+      Component: expect.any(Function),
       Errors: expect.objectContaining({__asyncLoader: expect.any(Function)}),
       Label: expect.objectContaining({__asyncLoader: expect.any(Function)}),
       field: {name: 'test', ref: 'value2', component: testComponent},

--- a/libs/core/src/utils/createField.ts
+++ b/libs/core/src/utils/createField.ts
@@ -21,6 +21,7 @@ import FormElementWrapper from '../components/FormElementWrapper';
 
 const createMainComponent = <Type = unknown, Props extends ComponentProps = ComponentProps>(
   field: FieldConfiguration<Type, Props>,
+  attrs: Record<string, unknown>,
 ): Component => {
   return defineComponent({
     setup() {
@@ -62,7 +63,16 @@ const createMainComponent = <Type = unknown, Props extends ComponentProps = Comp
       }
 
       return (
-        this.element && h(FormElementWrapper, {...this.$attrs, form: this.form, element: this.element}, this.$slots)
+        this.element && h(
+          FormElementWrapper,
+          {
+            ...attrs,
+            ...this.$attrs,
+            form: this.form,
+            element: this.element
+          },
+          this.$slots
+        )
       );
     },
   });
@@ -123,7 +133,7 @@ export const createField = <Type = unknown, Props extends ComponentProps = Compo
   return reactive({
     field,
     ref: (field.ref ?? ref<Type>()) as Type extends undefined ? undefined : Ref<Type>,
-    Component: markRaw(createMainComponent(field)),
+    Component: markRaw((_, ctx) => h(createMainComponent(field, ctx.attrs))),
     Errors: createAsyncComponent(() => createErrorComponent(field)),
     Label: createAsyncComponent(() => createLabelComponent(field)),
   });

--- a/libs/core/src/utils/createField.ts
+++ b/libs/core/src/utils/createField.ts
@@ -22,6 +22,7 @@ import FormElementWrapper from '../components/FormElementWrapper';
 const createMainComponent = <Type = unknown, Props extends ComponentProps = ComponentProps>(
   field: FieldConfiguration<Type, Props>,
   attrs: Record<string, unknown>,
+  slots: Record<string, unknown>,
 ): Component => {
   return defineComponent({
     setup() {
@@ -71,7 +72,10 @@ const createMainComponent = <Type = unknown, Props extends ComponentProps = Comp
             form: this.form,
             element: this.element
           },
-          this.$slots
+          {
+            ...this.$slots,
+            ...slots,
+          }
         )
       );
     },
@@ -133,7 +137,7 @@ export const createField = <Type = unknown, Props extends ComponentProps = Compo
   return reactive({
     field,
     ref: (field.ref ?? ref<Type>()) as Type extends undefined ? undefined : Ref<Type>,
-    Component: markRaw((_, ctx) => h(createMainComponent(field, ctx.attrs))),
+    Component: markRaw((_, ctx) => h(createMainComponent(field, ctx.attrs, ctx.slots))),
     Errors: createAsyncComponent(() => createErrorComponent(field)),
     Label: createAsyncComponent(() => createLabelComponent(field)),
   });

--- a/libs/core/src/utils/index.ts
+++ b/libs/core/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './defineField';
 export * from './defineForm';
 export * from './generateFieldName';
 export * from './markComponentAsRaw';
+export * from './updateMaybeRef';
 export * from './useDynamicWatcher';
 export {getDefaultFormConfiguration} from './getDefaultFormConfiguration';
 

--- a/libs/core/src/utils/updateMaybeRef.ts
+++ b/libs/core/src/utils/updateMaybeRef.ts
@@ -1,0 +1,10 @@
+import {isRef, type MaybeRef} from 'vue';
+
+export const updateMaybeRef = <T>(maybeRef: MaybeRef<T>, value: T): void => {
+  if (isRef(maybeRef)) {
+    maybeRef.value = value;
+    return;
+  }
+
+  maybeRef = value;
+};


### PR DESCRIPTION
Add a method  to add errors to a field
Add method to set a field to `isValid === false`
Update methods to also handle when the values are not refs anymore
Add support for fields to inherit passed attributes and slots