### PR TITLE
feat: add option to spread element props to the component

### DIFF
--- a/apps/vue-form-builder/src/__tests__/form/form.spec.ts
+++ b/apps/vue-form-builder/src/__tests__/form/form.spec.ts
@@ -1,4 +1,4 @@
-import {h, ref, reactive} from 'vue';
+import {h, ref, reactive, nextTick} from 'vue';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {flushPromises, mount} from '@vue/test-utils';
 import {getDefaultFormConfiguration} from '../../utils/getDefaultFormConfiguration';
@@ -214,6 +214,57 @@ describe('rendering a form', () => {
       await flushPromises();
 
       expect(form.instance.values).toEqual({field1: 'value', field2: 'hi', field3: ''});
+    });
+  });
+
+  describe('element props', () => {
+    it('passes down the instance props', async () => {
+      const {wrapper, form} = await renderTestForm( {
+        field: {
+          elementProp: 'spread',
+        }
+      });
+
+      const firstElement = wrapper.findComponent(mockComponent);
+      expect(firstElement.attributes('name')).toBe('field1');
+      expect(firstElement.attributes('isvisible')).toBe('true');
+      expect(firstElement.attributes('isdirty')).toBe('false');
+      expect(firstElement.attributes('isdisabled')).toBe('false');
+      expect(firstElement.attributes('isoptional')).toBe('false');
+      expect(firstElement.attributes('isreadonly')).toBe('false');
+      expect(firstElement.attributes('issuspended')).toBe('false');
+      expect(firstElement.attributes('istouched')).toBe('false');
+      expect(firstElement.attributes('isvalid')).toBe('true');
+    });
+
+    it('can set the isntance props with a field method', async () => {
+      const {wrapper, form} = await renderTestForm( {
+        field: {
+          elementProp: 'spread',
+        }
+      });
+
+      const firstElement = wrapper.findComponent(mockComponent);
+
+      form.instance.getField('field1')?.setVisible(false);
+      await nextTick();
+      expect(firstElement.attributes('isvisible')).toBe('false');
+
+      form.instance.getField('field1')?.setDisabled(true);
+      await nextTick();
+      expect(firstElement.attributes('isdisabled')).toBe('true');
+
+      form.instance.getField('field1')?.setOptional(true);
+      await nextTick();
+      expect(firstElement.attributes('isoptional')).toBe('true');
+
+      form.instance.getField('field1')?.setReadOnly(true);
+      await nextTick();
+      expect(firstElement.attributes('isreadonly')).toBe('true');
+
+      form.instance.getField('field1')?.setInvalid();
+      await nextTick();
+      expect(firstElement.attributes('isvalid')).toBe('false');
     });
   });
 });

--- a/apps/vue-form-builder/src/components/FormElement.vue
+++ b/apps/vue-form-builder/src/components/FormElement.vue
@@ -16,8 +16,8 @@
 
 <script lang="ts" setup>
 import {computed, toRefs, unref, isRef, type Ref} from 'vue';
-import type {ComponentProps} from '../types/component.types';
-import type {FieldInstance} from '../types/field.types';
+import {type FieldInstance, FIELD_INSTANCE_PROPS_KEYS} from '../types/field.types';
+import {type ComponentProps} from '../types/component.types';
 import {createFieldHooks} from '../composables/createFieldHooks';
 
 const props = defineProps<{element: FieldInstance}>();
@@ -38,6 +38,20 @@ const attributes = computed(() => {
 
   if (typeof props.element.component !== 'string' && elementProp !== false) {
     newProps.element = props.element;
+  }
+
+  /**
+   * Spread properties from `elementProp` array to `newProps`
+   * When the prop name is in the FieldInstanceProps
+   */
+  if (elementProp === 'spread') {
+    Object.keys(props.element).forEach((key) => {
+      const keyName = key as (typeof FIELD_INSTANCE_PROPS_KEYS)[number];
+
+      if (FIELD_INSTANCE_PROPS_KEYS.includes(keyName)) {
+        newProps[key] = props.element[keyName];
+      }
+    });
   }
 
   return newProps;

--- a/apps/vue-form-builder/src/index.ts
+++ b/apps/vue-form-builder/src/index.ts
@@ -11,6 +11,7 @@ export type {
   FieldSlots,
   FieldWrapperProps,
   ModularCreatedField,
+  FieldInstanceProps,
 } from './types/field.types';
 
 export type {CreatedForm, FormConfiguration, FormInstance, FormValues} from './types/form.types';

--- a/apps/vue-form-builder/src/types/field.types.ts
+++ b/apps/vue-form-builder/src/types/field.types.ts
@@ -247,3 +247,23 @@ export interface FieldProps<Type = unknown, Props = ComponentProps> extends Fiel
 }
 
 export type FieldEmits<Type = unknown> = (event: 'update:modelValue', value: Type) => void;
+
+export const FIELD_INSTANCE_PROPS_KEYS = [
+  'name',
+  'isVisible',
+  'isDirty',
+  'isDisabled',
+  'isOptional',
+  'isReadOnly',
+  'isSuspended',
+  'isTouched',
+  'isValid',
+] as const;
+
+/**
+ * The properties of a field instance that are spread into the component.
+ * This can be aded to the component props definition to make the field instance available in the component.
+ */
+export type FieldInstanceProps = Partial<
+  UnwrapNestedRefs<Pick<FieldInstance, (typeof FIELD_INSTANCE_PROPS_KEYS)[number]>>
+>;

--- a/apps/vue-form-builder/src/types/form.types.ts
+++ b/apps/vue-form-builder/src/types/form.types.ts
@@ -23,9 +23,13 @@ export interface FormConfiguration<Values extends FormValues = FormValues> exten
      * Whether to use the element as a prop on custom elements. Defaults to true. If set to false, your component
      * boilerplate can be more concise and omit the "element" prop without getting it as an extraneous attribute in
      * your html. You can still access the element via injection using useElement().
+     *
+     * When the value is 'spread', the element will be spread the FieldInstanceProps from the element to the component.
+     *
      * @see useElement
+     * @see FieldInstanceProps
      */
-    elementProp?: boolean;
+    elementProp?: boolean | 'spread';
   };
 
   /**
@@ -234,7 +238,7 @@ export interface BaseFormInstance<Values extends FormValues = FormValues> {
  */
 export interface InstanceFormConfiguration<V extends FormValues = FormValues> extends FormConfiguration<V> {
   field: {
-    elementProp: boolean;
+    elementProp: boolean | 'spread';
     wrapper?: ComponentOrHtmlElement;
   };
 


### PR DESCRIPTION
When `elementProps` is set to `spread` in the form config.
Spread the computed values and the name from the field instance on the component props.

Add a type that allows the user to add these props to their component easily.

```ts
import type {FieldInstanceProps} from '@myparcel/vue-form-builder';

defineProps<
  FieldInstanceProps & {
      [custom element props]
  }
>();
```