### PR TITLE
fix: make the FieldInstanceProps parseble in build steps

### DIFF
--- a/apps/vue-form-builder/src/types/field.types.ts
+++ b/apps/vue-form-builder/src/types/field.types.ts
@@ -264,6 +264,14 @@ export const FIELD_INSTANCE_PROPS_KEYS = [
  * The properties of a field instance that are spread into the component.
  * This can be aded to the component props definition to make the field instance available in the component.
  */
-export type FieldInstanceProps = Partial<
-  UnwrapNestedRefs<Pick<FieldInstance, (typeof FIELD_INSTANCE_PROPS_KEYS)[number]>>
->;
+export type FieldInstanceProps = {
+  name?: string;
+  isVisible?: boolean;
+  isDirty?: boolean;
+  isDisabled?: boolean;
+  isOptional?: boolean;
+  isReadOnly?: boolean;
+  isSuspended?: boolean;
+  isTouched?: boolean;
+  isValid?: boolean;
+};


### PR DESCRIPTION
When using the FieldInstanceProps and building an application it could not parse the prop correctly.

![image](https://github.com/user-attachments/assets/624d755c-64f2-484f-815c-a0d2dc24b280)
