### PR TITLE
fix: only set the element prop when elementProp is true

### DIFF
--- a/apps/vue-form-builder/src/components/FormElement.vue
+++ b/apps/vue-form-builder/src/components/FormElement.vue
@@ -36,7 +36,7 @@ const attributes = computed(() => {
     ...props.element.attributes,
   };
 
-  if (typeof props.element.component !== 'string' && elementProp !== false) {
+  if (typeof props.element.component !== 'string' && elementProp === true) {
     newProps.element = props.element;
   }
 


### PR DESCRIPTION
First it would only accept `true|false` now it also accepts `spread`. When `spread` was set, it would also add the `element` prop .This is unwanted since it already spreads the attributes from the `element`.