### PR TITLE
fix: disable Yarn hardened mode to fix CI

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,10 @@ compressionLevel: 0
 
 enableGlobalCache: true
 
+enableHardenedMode: false
+
+enableScripts: true
+
 ignorePath: true
 
 nodeLinker: node-modules


### PR DESCRIPTION
Fixes the Nx postinstall failure (exit code 129) in CI by disabling Yarn 4's hardened mode.

This is needed before the scope migration can be released, as the release workflow also hits this issue.