### PR TITLE
fix: upgrade upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: ./.github/actions/build
 
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./apps/demo/dist
 


### PR DESCRIPTION
Fixes deprecated actions/upload-pages-artifact@v1 which was causing the release workflow to fail.

The v1 version is deprecated and will stop working on January 30th, 2025. This upgrades to v3 which is the current stable version.