### PR TITLE
feat(vue-form-builder): export MagicForm as default for backward compatibility

### DIFF
--- a/apps/vue-form-builder/src/index.ts
+++ b/apps/vue-form-builder/src/index.ts
@@ -33,4 +33,8 @@ export {
   useFormBuilder,
 } from '@myparcel-vfb/core';
 
+// Backwards compatibility: also export MagicForm as default
+import {MagicForm as __MagicForm} from '@myparcel-vfb/core';
+export default __MagicForm;
+
 export {MyParcelFormBuilderPlugin, createMyParcelFormBuilderPlugin} from '@myparcel-vfb/plugin';


### PR DESCRIPTION
Adds default export for MagicForm alongside named export to avoid breaking consumers expecting default import.