### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,21 +32,41 @@
   },
   "targetDefaults": {
     "build:dev": {
-      "inputs": ["prod"],
-      "dependsOn": ["^build:dev"],
-      "outputs": ["{projectRoot}/dist", "{projectRoot}/*.tsbuildinfo"]
+      "inputs": [
+        "prod"
+      ],
+      "dependsOn": [
+        "^build:dev"
+      ],
+      "outputs": [
+        "{projectRoot}/dist",
+        "{projectRoot}/*.tsbuildinfo"
+      ]
     },
     "build": {
-      "inputs": ["prod"],
-      "dependsOn": ["^build"],
-      "outputs": ["{projectRoot}/dist", "{projectRoot}/*.tsbuildinfo"]
+      "inputs": [
+        "prod"
+      ],
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "{projectRoot}/dist",
+        "{projectRoot}/*.tsbuildinfo"
+      ]
     },
     "test:run": {
-      "inputs": ["test"]
+      "inputs": [
+        "test"
+      ]
     },
     "test:coverage": {
-      "inputs": ["test"],
-      "outputs": ["{workspaceRoot}/coverage"]
+      "inputs": [
+        "test"
+      ],
+      "outputs": [
+        "{workspaceRoot}/coverage"
+      ]
     }
   },
   "tasksRunnerOptions": {
@@ -76,5 +96,6 @@
         "accessToken": "ODE1MmI4YjctMmFiZC00YzNlLTg5YjUtMGIzNjgyMjI3NjhkfHJlYWQtd3JpdGU="
       }
     }
-  }
+  },
+  "nxCloudAccessToken": "ZGRkYzBjNmMtNDQ3Ni00MmQ2LWExZjctYmYyNDM5MmNlYjk2fHJlYWQtd3JpdGU="
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/638f379cf22350000e46dca9/workspaces/69aeb7876a41611ac7f188ec

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.