### PR TITLE
fix(beta): security fix tar vulnerability

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -12,10 +12,10 @@
     "typecheck": "run ws:vite:typecheck \"$(pwd)\""
   },
   "dependencies": {
+    "@myparcel-dev/constants": "^2.0.0",
+    "@myparcel-dev/sdk": "^4.0.0",
+    "@myparcel-dev/ts-utils": "^1.6.0",
     "@myparcel-dev/vue-form-builder": "workspace:*",
-    "@myparcel/constants": "^2.0.0",
-    "@myparcel/sdk": "^4.0.0",
-    "@myparcel/ts-utils": "^1.6.0",
     "@tanstack/vue-query": "^4.24.9",
     "@vueuse/core": "^10.1.2",
     "tailwindcss": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "axios": "1.15.0",
     "eslint-plugin-prettier": "^4.0.0"
     "eslint-plugin-prettier": "^4.0.0",
-    "tar": "^7.5.11"
+    "tar": "7.5.11"
   },
   "dependencies": {
     "@nrwl/nx-cloud": "^19.0.0"
@@ -66,7 +66,7 @@
     "array.prototype.flatmap": "^1.3.1",
     "bundlewatch": "^0.3.3",
     "conventional-changelog-conventionalcommits": "^7.0.2",
-    "eslint": "^8.34.0",
+    "eslint": "^9.26.0",
     "eslint-plugin-sort-exports": "^0.9.0",
     "husky": "^9.0.0",
     "is-ci": "^3.0.1",
@@ -78,13 +78,13 @@
     "vitest": "^2.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "20.15.1"
   },
   "volta": {
     "node": "20.15.1",
-    "yarn": "4.3.1"
+    "yarn": "4.12.0"
   },
-  "$comment": "Cache bust 2 - force new yarn install cache",
+  "$comment": "Cache bust 3 - force new yarn install cache",
   "bundlewatch": {
     "ci": {
       "trackBranches": [

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   "resolutions": {
     "axios": "1.15.0",
     "eslint-plugin-prettier": "^4.0.0"
+    "eslint-plugin-prettier": "^4.0.0",
+    "tar": "^7.5.11"
   },
   "dependencies": {
     "@nrwl/nx-cloud": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "array.prototype.flatmap": "^1.3.1",
     "bundlewatch": "^0.3.3",
     "conventional-changelog-conventionalcommits": "^7.0.2",
-    "eslint": "^9.26.0",
+    "eslint": "^8.34.0",
     "eslint-plugin-sort-exports": "^0.9.0",
     "husky": "^9.0.0",
     "is-ci": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "prettier": "@myparcel-dev/prettier-config",
   "resolutions": {
     "axios": "1.15.0",
-    "eslint-plugin-prettier": "^4.0.0"
     "eslint-plugin-prettier": "^4.0.0",
     "tar": "7.5.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/fs-minipass@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@isaacs/fs-minipass@npm:4.0.1"
+  dependencies:
+    minipass: "npm:^7.0.4"
+  checksum: 10c0/c25b6dc1598790d5b55c0947a9b7d111cfa92594db5296c3b907e2f533c033666f692a3939eadac17b1c7c40d362d0b0635dc874cbfe3e70db7c2b07cc97a5d2
+  languageName: node
+  linkType: hard
+
 "@istanbuljs/schema@npm:^0.1.2":
   version: 0.1.3
   resolution: "@istanbuljs/schema@npm:0.1.3"
@@ -851,6 +860,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@myparcel-dev/constants@npm:^2.0.0":
+  version: 2.9.2
+  resolution: "@myparcel-dev/constants@npm:2.9.2"
+  dependencies:
+    "@myparcel-dev/ts-utils": "npm:^1.15.0"
+  checksum: 10c0/59d959b9ecc9f05c8b71f660ff103bf87c1a7020290313f97518292350e6685155f6c88a821c38696b650e1aafa5f5a704b49a163de717108800b7224d48dcb4
+  languageName: node
+  linkType: hard
+
 "@myparcel-dev/eslint-config-es6@npm:^1.4.0":
   version: 1.4.0
   resolution: "@myparcel-dev/eslint-config-es6@npm:1.4.0"
@@ -1019,10 +1037,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@myparcel-dev/sdk@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "@myparcel-dev/sdk@npm:4.1.1"
+  dependencies:
+    "@myparcel-dev/constants": "npm:^2.0.0"
+    "@myparcel-dev/ts-utils": "npm:^1.6.0"
+  checksum: 10c0/c8233a1cada8243a1a08da313e216f5b369fdc6a810a60fe63f72ede5956b3b7e52b97d3838343eca372d8474581d7dd3cebd634615feb56ff1c63187a32c18c
+  languageName: node
+  linkType: hard
+
 "@myparcel-dev/ts-utils@npm:^1.15.0":
   version: 1.15.0
   resolution: "@myparcel-dev/ts-utils@npm:1.15.0"
   checksum: 10c0/fe0178f881cf78b44217b5f2c9a8ed92f3c15a58de1a19bb86b136589f1d1b95925a0e170ccf89507c6f574913b1f207804cd1a96135d63e4e8a71a6b6931f0e
+  languageName: node
+  linkType: hard
+
+"@myparcel-dev/ts-utils@npm:^1.6.0":
+  version: 1.15.1
+  resolution: "@myparcel-dev/ts-utils@npm:1.15.1"
+  checksum: 10c0/988cd4675c76e671ab943d3d8906df097b07de0bf91f7c77caea33901f2be70a53fd5bd83cd924367b1a71b756e9bed9e80ebad0d1b809a224b4dfdc0c165d6f
   languageName: node
   linkType: hard
 
@@ -1080,10 +1115,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-vfb/demo@workspace:apps/demo"
   dependencies:
+    "@myparcel-dev/constants": "npm:^2.0.0"
+    "@myparcel-dev/sdk": "npm:^4.0.0"
+    "@myparcel-dev/ts-utils": "npm:^1.6.0"
     "@myparcel-dev/vue-form-builder": "workspace:*"
-    "@myparcel/constants": "npm:^2.0.0"
-    "@myparcel/sdk": "npm:^4.0.0"
-    "@myparcel/ts-utils": "npm:^1.6.0"
     "@tanstack/vue-query": "npm:^4.24.9"
     "@testing-library/user-event": "npm:^14.5.2"
     "@vitejs/plugin-vue": "npm:^5.0.0"
@@ -1134,36 +1169,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@myparcel/constants@npm:^2.0.0":
-  version: 2.6.0
-  resolution: "@myparcel/constants@npm:2.6.0"
-  dependencies:
-    "@myparcel/ts-utils": "npm:^1.7.0"
-  checksum: 10c0/8da251e7d087c69b6a8e140ea0faaec78c5098314c8bf4d805d70623b3601995e132637cb594dfb91b184bf4e807209843509a04466c6e975b20720d73f1b70b
-  languageName: node
-  linkType: hard
-
 "@myparcel/prettier-config@npm:>= 1":
   version: 1.1.0
   resolution: "@myparcel/prettier-config@npm:1.1.0"
   checksum: 10c0/3253c037b7cb0fc0bd622b7be579e5ff1056fdf7fce86fc0ffba614cc4cad464deebe62928890b78baa749353cd7535caece717e50809ab428e2565c7c6fd02f
-  languageName: node
-  linkType: hard
-
-"@myparcel/sdk@npm:^4.0.0":
-  version: 4.4.2
-  resolution: "@myparcel/sdk@npm:4.4.2"
-  dependencies:
-    "@myparcel/constants": "npm:^2.0.0"
-    "@myparcel/ts-utils": "npm:^1.6.0"
-  checksum: 10c0/a86aa8c041dcb1f25d2d89ac9f2bc0c9af0922957c8014f4bb73ec00db127d7113b6d5d3efebb0aed93e9ad2bb474e128893b128d904604d080bc076a7f056fc
-  languageName: node
-  linkType: hard
-
-"@myparcel/ts-utils@npm:^1.6.0, @myparcel/ts-utils@npm:^1.7.0":
-  version: 1.14.0
-  resolution: "@myparcel/ts-utils@npm:1.14.0"
-  checksum: 10c0/13bf9521403e9761303cde9916932e12bdd50096a678de19282899809430086071e071851f49ce58fe3a9afb0b78fd807a5e0b7aa88344c30dfdae010b061866
   languageName: node
   linkType: hard
 
@@ -3790,10 +3799,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chownr@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "chownr@npm:2.0.0"
-  checksum: 10c0/594754e1303672171cc04e50f6c398ae16128eb134a88f801bf5354fd96f205320f23536a045d9abd8b51024a149696e51231565891d4efdab8846021ecf88e6
+"chownr@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chownr@npm:3.0.0"
+  checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
   languageName: node
   linkType: hard
 
@@ -5307,15 +5316,6 @@ __metadata:
     jsonfile: "npm:^4.0.0"
     universalify: "npm:^0.1.0"
   checksum: 10c0/1943bb2150007e3739921b8d13d4109abdc3cc481e53b97b7ea7f77eda1c3c642e27ae49eac3af074e3496ea02fde30f411ef410c760c70a38b92e656e5da784
-  languageName: node
-  linkType: hard
-
-"fs-minipass@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "fs-minipass@npm:2.1.0"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10c0/703d16522b8282d7299337539c3ed6edddd1afe82435e4f5b76e34a79cd74e488a8a0e26a636afc2440e1a23b03878e2122e3a2cfe375a5cf63c37d92b86a004
   languageName: node
   linkType: hard
 
@@ -7134,13 +7134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "minipass@npm:5.0.0"
-  checksum: 10c0/a91d8043f691796a8ac88df039da19933ef0f633e3d7f0d35dcd5373af49131cf2399bfc355f41515dc495e3990369c3858cd319e5c2722b4753c90bf3152462
-  languageName: node
-  linkType: hard
-
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
@@ -7148,7 +7141,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
+"minipass@npm:^7.0.4":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^2.1.2":
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
   dependencies:
@@ -7158,12 +7158,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "mkdirp@npm:1.0.4"
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
+"minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
+  dependencies:
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
   languageName: node
   linkType: hard
 
@@ -9134,17 +9134,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:6.2.1, tar@npm:^6.0.5, tar@npm:^6.1.11, tar@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "tar@npm:6.2.1"
+"tar@npm:7.5.11":
+  version: 7.5.11
+  resolution: "tar@npm:7.5.11"
   dependencies:
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.0.0"
-    minipass: "npm:^5.0.0"
-    minizlib: "npm:^2.1.1"
-    mkdirp: "npm:^1.0.3"
-    yallist: "npm:^4.0.0"
-  checksum: 10c0/a5eca3eb50bc11552d453488344e6507156b9193efd7635e98e867fab275d527af53d8866e2370cd09dfe74378a18111622ace35af6a608e5223a7d27fe99537
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
   languageName: node
   linkType: hard
 
@@ -10076,6 +10075,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "yallist@npm:5.0.0"
+  checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes ‘node-tar Symlink Path Traversal via Drive-Relative Linkpath’ by resolution to tar version 7.5.11.

Updates namespace myparcel packages in demo.